### PR TITLE
Modified the configure script to remove bash - as bash is not supported

### DIFF
--- a/patches/PR2.patch
+++ b/patches/PR2.patch
@@ -1,0 +1,14 @@
+diff --git a/configure b/configure
+index edbff6d..c41ad7f 100755
+--- a/configure
++++ b/configure
+@@ -215,7 +215,7 @@ do
+   as_found=:
+   case $as_dir in #(
+         /*)
+-          for as_base in sh bash ksh sh5; do
++          for as_base in sh ksh sh5; do
+             # Try only shells that exist, to save several forks.
+             as_shell=$as_dir$as_base
+             if { test -f "$as_shell" || test -f "$as_shell.exe"; } &&
+


### PR DESCRIPTION
the eval function in libtool is not working as expected when ar cr command is run with options which has newline chars when the script is run with bash. But this issue was not seen when ran with sh.

Hence, added a patch to remove bash here as a workaround till we port bash on zos.