### PR TITLE
Add version info for expat

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -21,3 +21,8 @@ totalTests:$totalTests
 expectedFailures:0
 ZZ
 }
+
+zopen_get_version()
+{
+  grep PACKAGE_VERSION expat_config.h | awk -F\" '{ print $2 }'
+}


### PR DESCRIPTION
libexpat is a library, so we query the version from the config.h